### PR TITLE
fix star density bug

### DIFF
--- a/Assets/SkyboxShaders/Skybox-StarrySky.shader
+++ b/Assets/SkyboxShaders/Skybox-StarrySky.shader
@@ -372,7 +372,7 @@ SubShader {
 				half3 center = round(pos);
 				half hash = dot(_StarsHash.xyz, center) % _StarsHash.w;
 				half threshold = _StarsHash.w * _StarsDensity;
-				if (hash < threshold)
+				if (abs(hash) < threshold)
 				{
 					half dist = length(pos - center);
 					half star = saturate(pow(saturate(0.5 - dist * dist) * 2, 14));


### PR DESCRIPTION
stars were allways on max density on half of the sky. this was because hash could tok negative values. fixed by using abs(hash)